### PR TITLE
fix(): Path for fxhammer2data

### DIFF
--- a/common/src/MakefileCommon
+++ b/common/src/MakefileCommon
@@ -54,7 +54,7 @@ MOD2GBT = $(ZGB_PATH_UNIX)/../tools/mod2gbt/mod2gbt
 UGE2SOURCE = $(ZGB_PATH_UNIX)/../tools/uge2source/uge2source
 VGM2DATA = $(ZGB_PATH_UNIX)/../tools/vgm2data/vgm2data
 WAV2DATA = python $(ZGB_PATH_UNIX)/../tools/wav2data/wav2data.py
-FXHAMMER2DATA = python $(ZGB_PATH_UNIX)/../tools/fxhammer2data/fxhammer2data
+FXHAMMER2DATA = $(ZGB_PATH_UNIX)/../tools/fxhammer2data/fxhammer2data
 FUR2JSON = python $(ZGB_PATH_UNIX)/../tools/banjo/furnace2json.py 
 JSON2SMS = python $(ZGB_PATH_UNIX)/../tools/banjo/json2sms.py
 


### PR DESCRIPTION
It looks like that fxhammer2data is now a compiled executable and not a python script anymore.
So we need to remove the python command in front of it.