### PR TITLE
Add "Lock Target" feature

### DIFF
--- a/common/include/SpriteManager.h
+++ b/common/include/SpriteManager.h
@@ -23,6 +23,9 @@ extern UINT8 enable_flickering;
 extern UINT8 THIS_IDX;
 extern Sprite* THIS;
 
+extern Sprite* lock_target;
+extern Sprite* active_lock_target;
+
 void SpriteManagerReset(void);
 
 void SpriteManagerLoad(UINT8 sprite_type);

--- a/common/src/Sprite.c
+++ b/common/src/Sprite.c
@@ -78,21 +78,23 @@ void DrawSprite(void) {
 	screen_x = THIS->x - scroll_x;
 	screen_y = THIS->y - scroll_y;
 
-	// tick sprite animation
-	if (THIS->anim_data) {	
-		THIS->anim_accum_ticks += THIS->anim_speed << delta_time;
-		if (THIS->anim_accum_ticks > 100u) {
-			THIS->anim_accum_ticks -= 100u;
+	// tick sprite animation unless a lock target exists
+	if ((active_lock_target == NULL) || (active_lock_target == THIS)) {
+		if (THIS->anim_data) {	
+			THIS->anim_accum_ticks += THIS->anim_speed << delta_time;
+			if (THIS->anim_accum_ticks > 100u) {
+				THIS->anim_accum_ticks -= 100u;
 
-			if (++THIS->anim_frame >= VECTOR_LEN(THIS->anim_data)) {
-				THIS->anim_frame = 0;
+				if (++THIS->anim_frame >= VECTOR_LEN(THIS->anim_data)) {
+					THIS->anim_frame = 0;
+				}
+	 
+				UINT8 tmp = VECTOR_GET(THIS->anim_data, THIS->anim_frame); // Do this before changing banks, anim_data is stored on current bank
+				UINT8 __save = CURRENT_BANK;
+				SWITCH_ROM(THIS->mt_sprite_bank);
+					THIS->mt_sprite = THIS->mt_sprite_info->metasprites[tmp];
+				SWITCH_ROM(__save);
 			}
- 
-			UINT8 tmp = VECTOR_GET(THIS->anim_data, THIS->anim_frame); // Do this before changing banks, anim_data is stored on current bank
-			UINT8 __save = CURRENT_BANK;
-			SWITCH_ROM(THIS->mt_sprite_bank);
-				THIS->mt_sprite = THIS->mt_sprite_info->metasprites[tmp];
-			SWITCH_ROM(__save);
 		}
 	}
 

--- a/common/src/main.c
+++ b/common/src/main.c
@@ -99,6 +99,7 @@ void main(void) {
 		state_running = TRUE;
 		current_state = next_state;
 		scroll_target = NULL;
+		lock_target = NULL;
 		last_tile_loaded = 0;
 #if defined(SEGA) || (defined(NINTENDO) && defined(CGB))
 		last_bg_pal_loaded = 0;


### PR DESCRIPTION
This pull request introduces new "Lock Target" functionality. Inspired by `scroll_target`, this function allows the user to define a sprite to have unlocked logic while every other sprite has paused logic. For the purpose of this pull request, the term "logic" refers to both a sprite's animation (from `DrawSprite();` in `Sprite.c`) and a sprite's `UPDATE` code.

This update introduces two new Sprite pointers, `lock_target` and `active_lock_target`. `lock_target` is intended to be modified by the user. It can be set to a Sprite pointer to mark the sprite as the only sprite with active logic, or can be set to NULL to unlock sprite logic and allow all sprites to run normally. `active_lock_target` is the sprite target that the engine uses and views, which is not meant to be modified by the user. The updated `SpriteManagerUpdate();` function sets `active_lock_target` to `lock_target` before iterating each sprite's update function, so that the engine's lock target does not present any discrepancies in behavior i `lock_target` changes as a result of something like a sprite's `UPDATE` code. Like `scroll_target`, `lock_target` gets changed to `NULL` when changing scenes.