### PR TITLE
Add "ANIM_STOP" feature

### DIFF
--- a/common/include/Sprite.h
+++ b/common/include/Sprite.h
@@ -74,6 +74,9 @@ typedef struct {
 #define SPRITE_SET_DEFAULT_PALETTE(SPRITE)
 #endif
 
+// Animation loop terminator
+#define ANIM_STOP 255
+
 void SetFrame(Sprite* sprite, UINT8 frame);
 void InitSprite(Sprite* sprite, UINT8 sprite_type);
 void SetSpriteAnim(Sprite* sprite, const UINT8* data, UINT8 speed);

--- a/common/src/Sprite.c
+++ b/common/src/Sprite.c
@@ -83,12 +83,21 @@ void DrawSprite(void) {
 		THIS->anim_accum_ticks += THIS->anim_speed << delta_time;
 		if (THIS->anim_accum_ticks > 100u) {
 			THIS->anim_accum_ticks -= 100u;
-
-			if (++THIS->anim_frame >= VECTOR_LEN(THIS->anim_data)) {
-				THIS->anim_frame = 0;
+			if ((VECTOR_GET(THIS->anim_data, THIS->anim_frame + 1) == ANIM_STOP) || (THIS->anim_frame == ANIM_STOP)) {
+				THIS->anim_frame = ANIM_STOP;
+			} else {
+				if (++THIS->anim_frame >= VECTOR_LEN(THIS->anim_data)) {
+					THIS->anim_frame = 0;
+				}
 			}
  
-			UINT8 tmp = VECTOR_GET(THIS->anim_data, THIS->anim_frame); // Do this before changing banks, anim_data is stored on current bank
+			UINT8 tmp = 0; // Do this before changing banks, anim_data is stored on current bank
+			if (THIS->anim_frame == ANIM_STOP) {
+				// if ANIM_STOP is used, then load the frame before ANIM_STOP
+				tmp = VECTOR_GET(THIS->anim_data, VECTOR_LEN(THIS->anim_data) - 2);
+			} else {
+				tmp = VECTOR_GET(THIS->anim_data, THIS->anim_frame);
+			}
 			UINT8 __save = CURRENT_BANK;
 			SWITCH_ROM(THIS->mt_sprite_bank);
 				THIS->mt_sprite = THIS->mt_sprite_info->metasprites[tmp];

--- a/common/src/Sprite.c
+++ b/common/src/Sprite.c
@@ -84,8 +84,10 @@ void DrawSprite(void) {
 		if (THIS->anim_accum_ticks > 100u) {
 			THIS->anim_accum_ticks -= 100u;
 			if ((VECTOR_GET(THIS->anim_data, THIS->anim_frame + 1) == ANIM_STOP) || (THIS->anim_frame == ANIM_STOP)) {
+				// if next or current frame is ANIM_STOP, set anim_frame to ANIM_STOP
 				THIS->anim_frame = ANIM_STOP;
 			} else {
+				// otherwise, run standard loop/frame logic
 				if (++THIS->anim_frame >= VECTOR_LEN(THIS->anim_data)) {
 					THIS->anim_frame = 0;
 				}
@@ -93,9 +95,10 @@ void DrawSprite(void) {
  
 			UINT8 tmp = 0; // Do this before changing banks, anim_data is stored on current bank
 			if (THIS->anim_frame == ANIM_STOP) {
-				// if ANIM_STOP is used, then load the frame before ANIM_STOP
+				// if anim_frame is ANIM_STOP, then load the frame before ANIM_STOP
 				tmp = VECTOR_GET(THIS->anim_data, VECTOR_LEN(THIS->anim_data) - 2);
 			} else {
+				// otherwise, run standard frame logic
 				tmp = VECTOR_GET(THIS->anim_data, THIS->anim_frame);
 			}
 			UINT8 __save = CURRENT_BANK;


### PR DESCRIPTION
Adds a `ANIM_STOP` definition, which can be placed at the end of animation vector. This definition is equal to `255`. Example:

```static const UINT8 anim_victory[] = VECTOR(6, 7, 8, ANIM_STOP);```

When a sprite reaches its last animation frame before the `ANIM_STOP` terminator (in this example, 8), its `THIS->anim_frame` value will instead be equal to `ANIM_STOP`. This can be utilized by users who want to know if a sprite with an `ANIM_STOP`  animation has reached its final animation frame.