### PR TITLE
Fixing wrong png2asset flags for sms backgrounds

### DIFF
--- a/common/src/MakefileCommon
+++ b/common/src/MakefileCommon
@@ -83,7 +83,7 @@ FLAGSPNG2ASSET_SPR += $(PNG2ASSET_SPR_$(EXT))
 PNG2ASSET_BKG_gb = -noflip
 PNG2ASSET_BKG_duck = $(PNG2ASSET_BKG_gb)
 PNG2ASSET_BKG_gg = -pack_mode sms -bpp 4 -keep_palette_order
-PNG2ASSET_BKG_sms = $(PNG2ASSET_SPR_gg)
+PNG2ASSET_BKG_sms = $(PNG2ASSET_BKG_gg)
 FLAGSPNG2ASSET_BKG += $(PNG2ASSET_BKG_$(EXT))
 
 #png2font cross-platform flags


### PR DESCRIPTION
Small fix to solve issue [Issue 35](https://github.com/gbdk-2020/CrossZGB/issues/35) , SMS backgrounds were reusing GG sprite flags, instead of GG background flags. 